### PR TITLE
feat(connection): implement connection lifecycle state machine

### DIFF
--- a/src/libp2p/Libp2p.Core.Tests/ConnectionStateMachineTests.cs
+++ b/src/libp2p/Libp2p.Core.Tests/ConnectionStateMachineTests.cs
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Nethermind.Libp2p.Core.Tests;
+
+[TestFixture]
+public class ConnectionStateMachineTests
+{
+    [Test]
+    public void Test_InitialState_IsDisconnected()
+    {
+        var machine = new ConnectionStateMachine();
+        Assert.That(machine.State, Is.EqualTo(ConnectionState.Disconnected));
+    }
+
+    [Test]
+    public void Test_NormalOutboundDialLifecycle_TransitionsSuccessfully()
+    {
+        var machine = new ConnectionStateMachine();
+        var changes = new List<ConnectionStateChangedEventArgs>();
+        machine.StateChanged += (s, e) => changes.Add(e);
+
+        // Disconnected -> Connecting
+        bool step1 = machine.TryTransition(ConnectionState.Connecting);
+        Assert.Multiple(() =>
+        {
+            Assert.That(step1, Is.True);
+            Assert.That(machine.State, Is.EqualTo(ConnectionState.Connecting));
+        });
+
+        // Connecting -> Connected
+        bool step2 = machine.TryTransition(ConnectionState.Connected);
+        Assert.Multiple(() =>
+        {
+            Assert.That(step2, Is.True);
+            Assert.That(machine.State, Is.EqualTo(ConnectionState.Connected));
+        });
+
+        // Connected -> Closed
+        bool step3 = machine.TryTransition(ConnectionState.Closed);
+        Assert.Multiple(() =>
+        {
+            Assert.That(step3, Is.True);
+            Assert.That(machine.State, Is.EqualTo(ConnectionState.Closed));
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(changes, Has.Count.EqualTo(3));
+            Assert.That(changes[0].Previous, Is.EqualTo(ConnectionState.Disconnected));
+            Assert.That(changes[0].Current, Is.EqualTo(ConnectionState.Connecting));
+            Assert.That(changes[1].Previous, Is.EqualTo(ConnectionState.Connecting));
+            Assert.That(changes[1].Current, Is.EqualTo(ConnectionState.Connected));
+            Assert.That(changes[2].Previous, Is.EqualTo(ConnectionState.Connected));
+            Assert.That(changes[2].Current, Is.EqualTo(ConnectionState.Closed));
+        });
+    }
+
+    [Test]
+    public void Test_InboundLifecycle_TransitionsDirectlyToConnected()
+    {
+        var machine = new ConnectionStateMachine();
+        bool step1 = machine.TryTransition(ConnectionState.Connected);
+        Assert.Multiple(() =>
+        {
+            Assert.That(step1, Is.True);
+            Assert.That(machine.State, Is.EqualTo(ConnectionState.Connected));
+        });
+    }
+
+    [Test]
+    public void Test_DialFailure_TransitionsToFailedWithException()
+    {
+        var machine = new ConnectionStateMachine();
+        var changes = new List<ConnectionStateChangedEventArgs>();
+        machine.StateChanged += (s, e) => changes.Add(e);
+
+        machine.TryTransition(ConnectionState.Connecting);
+        var originalException = new Exception("Connection refused");
+        bool step2 = machine.TryTransition(ConnectionState.Failed, originalException);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(step2, Is.True);
+            Assert.That(machine.State, Is.EqualTo(ConnectionState.Failed));
+            Assert.That(changes, Has.Count.EqualTo(2));
+            Assert.That(changes[1].Current, Is.EqualTo(ConnectionState.Failed));
+            Assert.That(changes[1].Error, Is.SameAs(originalException));
+        });
+    }
+
+    [Test]
+    public void Test_IllegalTransition_ThrowsInvalidOperationException()
+    {
+        var machine = new ConnectionStateMachine();
+        machine.TryTransition(ConnectionState.Connecting);
+        
+        // Cannot go from Connecting directly to Reconnecting
+        Assert.Throws<InvalidOperationException>(() => machine.TryTransition(ConnectionState.Reconnecting));
+    }
+
+    [Test]
+    public void Test_TryTransitionSafe_DoesNotThrowOnIllegalTransition()
+    {
+        var machine = new ConnectionStateMachine();
+        machine.TryTransition(ConnectionState.Connecting);
+
+        bool result = machine.TryTransitionSafe(ConnectionState.Reconnecting);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.False);
+            Assert.That(machine.State, Is.EqualTo(ConnectionState.Connecting));
+        });
+    }
+
+    [Test]
+    public void Test_FailedState_CanBeResetToDisconnected()
+    {
+        var machine = new ConnectionStateMachine();
+        machine.TryTransition(ConnectionState.Connecting);
+        machine.TryTransition(ConnectionState.Failed);
+
+        bool resetResult = machine.ResetToDisconnected();
+        Assert.Multiple(() =>
+        {
+            Assert.That(resetResult, Is.True);
+            Assert.That(machine.State, Is.EqualTo(ConnectionState.Disconnected));
+        });
+    }
+
+    [Test]
+    public void Test_ClosedIsTerminal_DoesNotAllowAnyFurtherTransitions()
+    {
+        var machine = new ConnectionStateMachine();
+        machine.TryTransition(ConnectionState.Connected);
+        machine.TryTransition(ConnectionState.Closed);
+
+        // Try transitioning Closed -> Reconnecting or Closed -> Disconnected
+        Assert.Throws<InvalidOperationException>(() => machine.TryTransition(ConnectionState.Reconnecting));
+        Assert.Throws<InvalidOperationException>(() => machine.TryTransition(ConnectionState.Disconnected));
+    }
+
+    [Test]
+    public void Test_ReconnectingFlows_TransitionCorrectly()
+    {
+        var machine = new ConnectionStateMachine();
+        machine.TryTransition(ConnectionState.Connected);
+
+        // Transition Connected -> Reconnecting
+        bool step1 = machine.TryTransition(ConnectionState.Reconnecting);
+        Assert.Multiple(() =>
+        {
+            Assert.That(step1, Is.True);
+            Assert.That(machine.State, Is.EqualTo(ConnectionState.Reconnecting));
+        });
+
+        // Reconnecting -> Connected (Success recovery)
+        bool step2 = machine.TryTransition(ConnectionState.Connected);
+        Assert.Multiple(() =>
+        {
+            Assert.That(step2, Is.True);
+            Assert.That(machine.State, Is.EqualTo(ConnectionState.Connected));
+        });
+    }
+
+    [Test]
+    public async Task Test_ConcurrentTimeTransitions_EnforcesStrictAtomicity()
+    {
+        var machine = new ConnectionStateMachine();
+        int successfulTransitions = 0;
+        int transitionAttempts = 100;
+        var tasks = new List<Task>();
+
+        // Set to Connecting first
+        machine.TryTransition(ConnectionState.Connecting);
+
+        for (int i = 0; i < transitionAttempts; i++)
+        {
+            tasks.Add(Task.Run(() =>
+            {
+                if (machine.TryTransitionSafe(ConnectionState.Connected))
+                {
+                    Interlocked.Increment(ref successfulTransitions);
+                }
+            }));
+        }
+
+        await Task.WhenAll(tasks);
+
+        // Since CAS guarantees thread-safety and atomicity, only exactly ONE thread
+        // must successfully perform the state transition. All others must return false.
+        Assert.That(successfulTransitions, Is.EqualTo(1));
+    }
+}

--- a/src/libp2p/Libp2p.Core.TestsBase/LocalPeerStub.cs
+++ b/src/libp2p/Libp2p.Core.TestsBase/LocalPeerStub.cs
@@ -68,6 +68,9 @@ public class TestRemotePeer : ISession
 
     public Activity? Activity => throw new NotImplementedException();
 
+    public ConnectionState ConnectionState => ConnectionState.Connected;
+    public event EventHandler<ConnectionStateChangedEventArgs>? ConnectionStateChanged;
+
     public Task DialAsync<TProtocol>(CancellationToken token = default) where TProtocol : ISessionProtocol
     {
         return Task.CompletedTask;

--- a/src/libp2p/Libp2p.Core/ConnectionLifecycle/ConnectionState.cs
+++ b/src/libp2p/Libp2p.Core/ConnectionLifecycle/ConnectionState.cs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+namespace Nethermind.Libp2p.Core;
+
+/// <summary>
+/// Represents the states of a Libp2p connection lifecycle.
+/// </summary>
+public enum ConnectionState
+{
+    Disconnected,
+    Connecting,
+    Connected,
+    Reconnecting,
+    Closed,
+    Failed
+}

--- a/src/libp2p/Libp2p.Core/ConnectionLifecycle/ConnectionStateChangedEventArgs.cs
+++ b/src/libp2p/Libp2p.Core/ConnectionLifecycle/ConnectionStateChangedEventArgs.cs
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using System;
+
+namespace Nethermind.Libp2p.Core;
+
+/// <summary>
+/// Provides event data for connection state changes.
+/// </summary>
+public sealed class ConnectionStateChangedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets the state before the transition.
+    /// </summary>
+    public ConnectionState Previous { get; }
+
+    /// <summary>
+    /// Gets the state after the transition.
+    /// </summary>
+    public ConnectionState Current { get; }
+
+    /// <summary>
+    /// Gets the exception that caused the transition to Failed, if any.
+    /// </summary>
+    public Exception? Error { get; }
+
+    /// <summary>
+    /// Gets the timestamp when the state transition occurred.
+    /// </summary>
+    public DateTimeOffset ChangedAt { get; }
+
+    public ConnectionStateChangedEventArgs(ConnectionState previous, ConnectionState current, Exception? error = null)
+    {
+        Previous = previous;
+        Current = current;
+        Error = error;
+        ChangedAt = DateTimeOffset.UtcNow;
+    }
+}

--- a/src/libp2p/Libp2p.Core/ConnectionLifecycle/ConnectionStateMachine.cs
+++ b/src/libp2p/Libp2p.Core/ConnectionLifecycle/ConnectionStateMachine.cs
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Threading;
+
+namespace Nethermind.Libp2p.Core;
+
+/// <summary>
+/// A thread-safe, lock-free state machine for managing a connection lifecycle.
+/// </summary>
+internal sealed class ConnectionStateMachine
+{
+    private int _state; // Stores the current state as an integer representation of ConnectionState
+
+    /// <summary>
+    /// Gets the current state of the connection.
+    /// </summary>
+    public ConnectionState State => (ConnectionState)Volatile.Read(ref _state);
+
+    /// <summary>
+    /// Occurs when the connection state has transitioned successfully.
+    /// </summary>
+    public event EventHandler<ConnectionStateChangedEventArgs>? StateChanged;
+
+    public ConnectionStateMachine(ConnectionState initialState = ConnectionState.Disconnected)
+    {
+        _state = (int)initialState;
+    }
+
+    /// <summary>
+    /// Attempts to transition to the specified target state.
+    /// Throws an InvalidOperationException if the transition is illegal.
+    /// </summary>
+    public bool TryTransition(ConnectionState to, Exception? error = null)
+    {
+        while (true)
+        {
+            ConnectionState current = State;
+
+            if (current == to)
+            {
+                return false; // Already in the target state
+            }
+
+            if (!IsValidTransition(current, to))
+            {
+                throw new InvalidOperationException($"Invalid state transition from '{current}' to '{to}'.");
+            }
+
+            if (Interlocked.CompareExchange(ref _state, (int)to, (int)current) == (int)current)
+            {
+                OnStateChanged(current, to, error);
+                return true;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Attempts to transition to the specified target state.
+    /// Does not throw on illegal transition; instead returns false.
+    /// </summary>
+    public bool TryTransitionSafe(ConnectionState to, Exception? error = null)
+    {
+        try
+        {
+            return TryTransition(to, error);
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Resets a Failed state back to Disconnected to allow retry/redial attempts.
+    /// </summary>
+    public bool ResetToDisconnected()
+    {
+        return TryTransitionSafe(ConnectionState.Disconnected);
+    }
+
+    private static bool IsValidTransition(ConnectionState from, ConnectionState to)
+    {
+        return (from, to) switch
+        {
+            // From Disconnected
+            (ConnectionState.Disconnected, ConnectionState.Connecting) => true,
+            (ConnectionState.Disconnected, ConnectionState.Connected) => true, // Inbound connections direct to Connected
+            (ConnectionState.Disconnected, ConnectionState.Closed) => true,
+
+            // From Connecting
+            (ConnectionState.Connecting, ConnectionState.Connected) => true,
+            (ConnectionState.Connecting, ConnectionState.Failed) => true,
+            (ConnectionState.Connecting, ConnectionState.Closed) => true,
+
+            // From Connected
+            (ConnectionState.Connected, ConnectionState.Reconnecting) => true,
+            (ConnectionState.Connected, ConnectionState.Closed) => true,
+            (ConnectionState.Connected, ConnectionState.Failed) => true,
+
+            // From Reconnecting
+            (ConnectionState.Reconnecting, ConnectionState.Connected) => true,
+            (ConnectionState.Reconnecting, ConnectionState.Failed) => true,
+            (ConnectionState.Reconnecting, ConnectionState.Closed) => true,
+
+            // From Failed (allow reset back to Disconnected to redial/retry)
+            (ConnectionState.Failed, ConnectionState.Disconnected) => true,
+            (ConnectionState.Failed, ConnectionState.Closed) => true,
+
+            // From Closed (terminal state, no transitions allowed out of Closed)
+            _ => false
+        };
+    }
+
+    private void OnStateChanged(ConnectionState previous, ConnectionState current, Exception? error)
+    {
+        StateChanged?.Invoke(this, new ConnectionStateChangedEventArgs(previous, current, error));
+    }
+}

--- a/src/libp2p/Libp2p.Core/ISession.cs
+++ b/src/libp2p/Libp2p.Core/ISession.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 using Multiformats.Address;
+using System;
 using System.Diagnostics;
 
 namespace Nethermind.Libp2p.Core;
@@ -10,6 +11,8 @@ public interface ISession
 {
     Multiaddress RemoteAddress { get; }
     Activity? Activity { get; }
+    ConnectionState ConnectionState { get; }
+    event EventHandler<ConnectionStateChangedEventArgs>? ConnectionStateChanged;
 
     Task DialAsync<TProtocol>(CancellationToken token = default) where TProtocol : ISessionProtocol;
     Task<TResponse> DialAsync<TProtocol, TRequest, TResponse>(TRequest request, CancellationToken token = default) where TProtocol : ISessionProtocol<TRequest, TResponse>;

--- a/src/libp2p/Libp2p.Core/LocalPeer.Session.cs
+++ b/src/libp2p/Libp2p.Core/LocalPeer.Session.cs
@@ -4,20 +4,36 @@
 using Multiformats.Address;
 using Nethermind.Libp2p.Core.Exceptions;
 using Nethermind.Libp2p.Core.Metrics;
+using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Nethermind.Libp2p.Core;
 
 public partial class LocalPeer
 {
-    public class Session(LocalPeer peer) : ISession
+    public class Session : ISession
     {
         private static int SessionIdCounter;
+        private readonly ConnectionStateMachine _stateMachine;
+        private readonly LocalPeer _peer;
+
+        public Session(LocalPeer peer)
+        {
+            _peer = peer;
+            _stateMachine = new ConnectionStateMachine();
+            _stateMachine.StateChanged += OnStateChanged;
+        }
 
         public string Id { get; } = Interlocked.Increment(ref SessionIdCounter).ToString();
         public State State { get; } = new();
         public Activity? Activity { get; }
+
+        public ConnectionState ConnectionState => _stateMachine.State;
+        public event EventHandler<ConnectionStateChangedEventArgs>? ConnectionStateChanged;
 
         public Multiaddress RemoteAddress => State.RemoteAddress ?? throw new Libp2pException("Session contains uninitialized remote address.");
 
@@ -26,7 +42,7 @@ public partial class LocalPeer
         public async Task DialAsync<TProtocol>(CancellationToken token = default) where TProtocol : ISessionProtocol
         {
             TaskCompletionSource<object?> tcs = new();
-            SubDialRequests.Add(new UpgradeOptions() { CompletionSource = tcs!, SelectedProtocol = peer.GetProtocolInstance<TProtocol>() }, token);
+            SubDialRequests.Add(new UpgradeOptions() { CompletionSource = tcs!, SelectedProtocol = _peer.GetProtocolInstance<TProtocol>() }, token);
             await tcs.Task;
             MarkAsConnected();
         }
@@ -42,31 +58,63 @@ public partial class LocalPeer
         public async Task<TResponse> DialAsync<TProtocol, TRequest, TResponse>(TRequest request, CancellationToken token = default) where TProtocol : ISessionProtocol<TRequest, TResponse>
         {
             TaskCompletionSource<object?> tcs = new();
-            SubDialRequests.Add(new UpgradeOptions() { CompletionSource = tcs, SelectedProtocol = peer.GetProtocolInstance<TProtocol>(), Argument = request }, token);
+            SubDialRequests.Add(new UpgradeOptions() { CompletionSource = tcs, SelectedProtocol = _peer.GetProtocolInstance<TProtocol>(), Argument = request }, token);
             await tcs.Task;
             MarkAsConnected();
             return (TResponse)tcs.Task.Result!;
         }
 
-
         private CancellationTokenSource connectionTokenSource = new();
 
         public Task DisconnectAsync()
         {
+            _stateMachine.TryTransitionSafe(ConnectionState.Closed);
             connectionTokenSource.Cancel();
-            peer.RemoveSession(this);
+            _peer.RemoveSession(this);
             return Task.CompletedTask;
         }
 
         public CancellationToken ConnectionToken => connectionTokenSource.Token;
 
-
         public TaskCompletionSource ConnectedTcs = new();
         public Task Connected => ConnectedTcs.Task;
 
-        internal void MarkAsConnected() => ConnectedTcs?.TrySetResult();
+        internal void MarkAsConnected()
+        {
+            _stateMachine.TryTransitionSafe(ConnectionState.Connected);
+            ConnectedTcs?.TrySetResult();
+        }
+
+        internal bool TryTransition(ConnectionState target, Exception? error = null)
+        {
+            return _stateMachine.TryTransition(target, error);
+        }
+
+        internal bool TryTransitionSafe(ConnectionState target, Exception? error = null)
+        {
+            return _stateMachine.TryTransitionSafe(target, error);
+        }
 
         internal IEnumerable<UpgradeOptions> GetRequestQueue() => SubDialRequests.GetConsumingEnumerable(ConnectionToken);
+
+        private void OnStateChanged(object? sender, ConnectionStateChangedEventArgs e)
+        {
+            // Publish/forward the event to outer listeners
+            ConnectionStateChanged?.Invoke(this, e);
+
+            // Increment transition counter
+            Libp2pMetrics.ConnectionStateTransitions.Add(1);
+
+            // Log transitions using source-generated loggers
+            if (e.Current == ConnectionState.Failed)
+            {
+                _peer._logger?.ConnectionFailed(Id, e.Error?.Message ?? "Unknown failure", e.Error);
+            }
+            else
+            {
+                _peer._logger?.ConnectionStateChanged(Id, e.Previous.ToString(), e.Current.ToString());
+            }
+        }
     }
 
     private void RemoveSession(Session session)
@@ -74,6 +122,12 @@ public partial class LocalPeer
         lock (Sessions)
         {
             Sessions.Remove(session);
+        }
+        if (session.ConnectionState == ConnectionState.Connected)
+        {
+            session.TryTransitionSafe(ConnectionState.Reconnecting);
+            Libp2pMetrics.ReconnectAttempts.Add(1);
+            session.TryTransitionSafe(ConnectionState.Failed, new Libp2pException("Connection lost due to transport failure"));
         }
         Libp2pMetrics.SessionsClosed.Add(1);
         Libp2pMetrics.SessionsActive.Add(-1);

--- a/src/libp2p/Libp2p.Core/LogMessages.cs
+++ b/src/libp2p/Libp2p.Core/LogMessages.cs
@@ -136,4 +136,40 @@ internal static partial class LogMessages
         string protocol,
         Exception? exception,
         string errorMessage);
+
+    [LoggerMessage(
+        EventId = EventId + 20,
+        EventName = nameof(ConnectionStateChanged),
+        Message = "Connection {sessionId} changed state from {previousState} to {currentState}",
+        Level = LogLevel.Debug,
+        SkipEnabledCheck = true)]
+    internal static partial void ConnectionStateChanged(
+        this ILogger logger,
+        string sessionId,
+        string previousState,
+        string currentState);
+
+    [LoggerMessage(
+        EventId = EventId + 21,
+        EventName = nameof(ConnectionTransitionFailed),
+        Message = "Connection {sessionId} failed transition from {currentState} to {targetState}",
+        Level = LogLevel.Warning,
+        SkipEnabledCheck = true)]
+    internal static partial void ConnectionTransitionFailed(
+        this ILogger logger,
+        string sessionId,
+        string currentState,
+        string targetState);
+
+    [LoggerMessage(
+        EventId = EventId + 22,
+        EventName = nameof(ConnectionFailed),
+        Message = "Connection {sessionId} failed: {errorMessage}",
+        Level = LogLevel.Error,
+        SkipEnabledCheck = true)]
+    internal static partial void ConnectionFailed(
+        this ILogger logger,
+        string sessionId,
+        string errorMessage,
+        Exception? exception);
 }

--- a/src/libp2p/Libp2p.Core/Metrics/Libp2pMetrics.cs
+++ b/src/libp2p/Libp2p.Core/Metrics/Libp2pMetrics.cs
@@ -65,4 +65,11 @@ public static class Libp2pMetrics
     // --- Error metrics ---
     public static readonly Counter<long> Errors =
         Meter.CreateCounter<long>("libp2p.errors", description: "Total errors encountered");
+
+    // --- Lifecycle metrics ---
+    public static readonly Counter<long> ConnectionStateTransitions =
+        Meter.CreateCounter<long>("libp2p.connections.state_transitions", description: "Total connection state machine transitions");
+
+    public static readonly Counter<long> ReconnectAttempts =
+        Meter.CreateCounter<long>("libp2p.connections.reconnect_attempts", description: "Total connection reconnection attempts");
 }

--- a/src/libp2p/Libp2p.Core/Peer.cs
+++ b/src/libp2p/Libp2p.Core/Peer.cs
@@ -187,11 +187,13 @@ public partial class LocalPeer(Identity identity, PeerStore peerStore, IProtocol
         {
             if (t.IsFaulted)
             {
+                var initEx = t.Exception?.InnerException ?? t.Exception;
+                session.TryTransitionSafe(ConnectionState.Failed, initEx);
                 _ = session.DisconnectAsync();
                 _logger?.LogError(t.Exception.InnerException, $"Disconnecting due to exception");
                 return;
             }
-            session.ConnectedTcs.TrySetResult();
+            session.MarkAsConnected();
             OnConnected?.Invoke(session);
         });
         return new NewSessionContext(this, session, proto, isListener, null, activitySource, activity, loggerFactory);
@@ -324,6 +326,7 @@ public partial class LocalPeer(Identity identity, PeerStore peerStore, IProtocol
         }
 
         Session session = new(this);
+        session.TryTransitionSafe(ConnectionState.Connecting);
         ITransportContext ctx = new DialerTransportContext(this, session, dialerProtocol, dialActivity);
 
         Task dialingTask = transportProtocol.DialAsync(ctx, addr, token);
@@ -337,11 +340,15 @@ public partial class LocalPeer(Identity identity, PeerStore peerStore, IProtocol
             Libp2pMetrics.DialFailures.Add(1);
             if (dialingResult.IsFaulted)
             {
+                var dialEx = dialingResult.Exception?.InnerException ?? dialingResult.Exception;
+                session.TryTransitionSafe(ConnectionState.Failed, dialEx);
                 dialActivity?.SetStatus(ActivityStatusCode.Error, dialingResult.Exception.Message);
                 dialActivity?.Dispose();
                 throw dialingResult.Exception;
             }
-            throw new Libp2pException("Not able to dial the peer");
+            var failedEx = new Libp2pException("Not able to dial the peer");
+            session.TryTransitionSafe(ConnectionState.Failed, failedEx);
+            throw failedEx;
         }
 
         double elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;


### PR DESCRIPTION
## Description

Sessions in dotnet-libp2p had no formal way to track connection state 
there was no way to tell whether a session was dialling, established, trying to reconnect, or permanently failed.

This adds a thread-safe, lock-free ConnectionStateMachine that governs 
the full session lifecycle:

Disconnected → Connecting → Connected → Reconnecting → Failed → Disconnected
(Closed is terminal — no transitions out)

Wired into LocalPeer.Session so state transitions happen automatically during dial, disconnect, and failure flows. ISession now exposes ConnectionState and a ConnectionStateChanged event so anything consuming a session can react to changes without polling.

Also adds structured logging and System.Diagnostics.Metrics counters for state transitions and reconnect attempts useful for observability in production deployments.

This builds directly on the address-matching work from #6 together they form the groundwork for a full WebRTC transport implementation.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Tests (adding new or updating existing tests)

## Additional Information

Tested locally with NUnit:

dotnet test --filter "FullyQualifiedName~ConnectionStateMachine"

10 tests: 10 passed, 0 failed. Build succeeded in 9.6s.

Screenshot attached.

<img width="1058" height="572" alt="donet" src="https://github.com/user-attachments/assets/41eaeadf-026c-4d30-8a70-7255b14fb1c3" />
